### PR TITLE
function name with an exclamation symbol

### DIFF
--- a/src/QP.jl
+++ b/src/QP.jl
@@ -1,10 +1,15 @@
 using LinearAlgebra
-export solveQP
+export solveQP!, solveQP
 
 #  This routine implements the dual method of Goldfarb and Idnani (1982, 1983) for solving quadratic programming problems of the form
 # \eqn{\min(-d^T b + 1/2 b^T D b)}{min(-d^T b + 1/2 b^T D b)} with the
 # constraints \eqn{A^T b >= b_0}.
 function solveQP(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
+    Amat::AbstractMatrix{T}, bvec::AbstractArray{T};
+    meq::Int = 0, factorized::Bool = false)::Tuple{AbstractArray{T},AbstractArray{T},T,AbstractArray{Int},Int,AbstractArray{Int}} where {T} #sol, lagr, crval, iact, nact, iter
+    return solveQP!(copy(dmat), copy(dvec), Amat, bvec; meq = meq, factorized = factorized)
+end
+function solveQP!(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
     Amat::AbstractMatrix{T}, bvec::AbstractArray{T};
     meq::Int = 0, factorized::Bool = false)::Tuple{AbstractArray{T},AbstractArray{T},T,AbstractArray{Int},Int,AbstractArray{Int}} where {T} #sol, lagr, crval, iact, nact, iter
     n = size(dmat, 1)
@@ -31,7 +36,7 @@ function solveQP(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
     end
     r = min(n, q)
     work = zeros(T, 2 * n + trunc(Int, r * (r + 5) / 2) + 2 * q + 1)
-    sol, lagr, crval, iact, nact, iter, ierr = qpgen2(dmat, dvec, n, n, Amat, bvec, anrow, q, meq, factorized, work)
+    sol, lagr, crval, iact, nact, iter, ierr = qpgen2!(dmat, dvec, n, n, Amat, bvec, anrow, q, meq, factorized, work)
     if ierr == 1
         throw(error("constraints are inconsistent, no solution!"))
     elseif ierr == 2
@@ -108,7 +113,7 @@ end
 #   work  vector with length at least 2*n+r*(r+5)/2 + 2*q +1
 #         where r=min(n,q)
 # 
-function qpgen2(dmat::AbstractMatrix{T}, dvec::AbstractArray{T}, fddmat::Int, n::Int, amat::AbstractMatrix{T},
+function qpgen2!(dmat::AbstractMatrix{T}, dvec::AbstractArray{T}, fddmat::Int, n::Int, amat::AbstractMatrix{T},
    bvec::AbstractArray{T}, fdamat::Int, q::Int, meq::Int, factorized::Bool, work::AbstractArray{T})::Tuple{AbstractArray{T},AbstractArray{T},T,AbstractArray{Int},Int,AbstractArray{Int},Int} where {T} # sol, lagr, crval, iact, nact, iter, ierr
 
    sol = zeros(T, n)

--- a/src/QP.jl
+++ b/src/QP.jl
@@ -7,7 +7,7 @@ export solveQP!, solveQP
 function solveQP(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
     Amat::AbstractMatrix{T}, bvec::AbstractArray{T};
     meq::Int = 0, factorized::Bool = false)::Tuple{AbstractArray{T},AbstractArray{T},T,AbstractArray{Int},Int,AbstractArray{Int}} where {T} #sol, lagr, crval, iact, nact, iter
-    return solveQP!(copy(dmat), copy(dvec), Amat, bvec; meq = meq, factorized = factorized)
+    return solveQP!(Matrix(dmat), Vector(dvec), Amat, bvec; meq = meq, factorized = factorized)
 end
 function solveQP!(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
     Amat::AbstractMatrix{T}, bvec::AbstractArray{T};

--- a/src/QPcompact.jl
+++ b/src/QPcompact.jl
@@ -7,7 +7,7 @@ export solveQPcompact!, solveQPcompact, convertSparse
 function solveQPcompact(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},
     Amat::AbstractMatrix{T}, Aind::AbstractMatrix{Int}, bvec::AbstractArray{T};
     meq::Int = 0, factorized::Bool = false)::Tuple{AbstractArray{T},AbstractArray{T},T,AbstractArray{Int},Int,AbstractArray{Int}} where {T} #sol, lagr, crval, iact, nact, iter
-    return solveQPcompact!(copy(dmat), copy(dvec), Amat, Aind, bvec, meq = meq, factorized = factorized)
+    return solveQPcompact!(Matrix(dmat), Vector(dvec), Amat, Aind, bvec, meq = meq, factorized = factorized)
 end
 
 function solveQPcompact!(dmat::AbstractMatrix{T}, dvec::AbstractArray{T},


### PR DESCRIPTION
> By convention, function names ending with an exclamation point (!) modify their arguments.
> https://docs.julialang.org/en/v1/base/base/#Introduction

Note that both `dmat` and `dvec` are destroyed in the functions, it will be better to remind users that the function will change the input arrays using `!` symbol.

So this pull request append an exclamation symbol to those functions, but also wrap up the version without an exclamation symbol by passing `copy(dmat)` and `copy(dvec)`.

Furthermore, it would be better to use `Matrix(dmat)` instead of `copy(dmat)`, and similarly `Vector(dvec)` instead of `copy(dvec)`. Because `dmat` and `dvec` might not be editable, for example

```
julia> dmat = 1.0I(3)
3×3 Diagonal{Float64, Vector{Float64}}:
 1.0   ⋅    ⋅ 
  ⋅   1.0   ⋅ 
  ⋅    ⋅   1.0

julia> dmat[2,3] = 1.0
ERROR: ArgumentError: cannot set off-diagonal entry (2, 3) to a nonzero value (1.0)
Stacktrace:
 [1] setindex!(D::Diagonal{Float64, Vector{Float64}}, v::Float64, i::Int64, j::Int64)
   @ LinearAlgebra /media/weiya/PSSD/Programs/julia-1.8.1/share/julia/stdlib/v1.8/LinearAlgebra/src/diagonal.jl:129
 [2] top-level scope
   @ REPL[39]:1

julia> dvec = 1:3
1:3

julia> dvec[3] = 4
ERROR: CanonicalIndexError: setindex! not defined for UnitRange{Int64}
Stacktrace:
 [1] error_if_canonical_setindex(#unused#::IndexLinear, A::UnitRange{Int64}, #unused#::Int64)
   @ Base ./abstractarray.jl:1352
 [2] setindex!(A::UnitRange{Int64}, v::Int64, I::Int64)
   @ Base ./abstractarray.jl:1343
 [3] top-level scope
   @ REPL[41]:1
```

With `Matrix(dmat)`, it will also make a copy for `dmat`, but also make it a standard matrix, which can always be editable. Similar for `Vector(dvec)`.